### PR TITLE
An adjustment to the 'img =' cv2 call to still execute in a different…

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -92,8 +92,11 @@ for idx, path in enumerate(images, 1):
     os.makedirs(output_dir, exist_ok=True)
     print(idx, base)
     # read image
-    img = cv2.imread(path, cv2.cv2.IMREAD_COLOR)
-
+    try: 
+        img = cv2.imread(path, cv2.cv2.IMREAD_COLOR)
+    except:
+        img = cv2.imread(path, cv2.IMREAD_COLOR)
+        
     # Seamless modes
     if args.seamless:
         img = cv2.copyMakeBorder(img, 16, 16, 16, 16, cv2.BORDER_WRAP)


### PR DESCRIPTION
…/newer python environment, instead of failing

I know this is unmaintained - but just a quick n' dirty fix to still run just in case anyone else comes across this project in the future and is running a newer implementation of python/opencv, like me